### PR TITLE
Fix crash when passed an empty string.

### DIFF
--- a/Source/MMMarkdown.m
+++ b/Source/MMMarkdown.m
@@ -40,6 +40,8 @@
 {
     if (string == nil)
         return nil;
+    if ([string length] == 0)
+        return @"";
     
     MMParser    *parser    = [MMParser new];
     MMGenerator *generator = [MMGenerator new];


### PR DESCRIPTION
I noticed an assertion failure when passing an empty string. This fixes the crash by detecting the empty string early and just returning an empty string.
