### PR TITLE
Add CSS support for GitHub like rendering

### DIFF
--- a/Source/MMGenerator.m
+++ b/Source/MMGenerator.m
@@ -180,6 +180,14 @@ static NSString * __HTMLEndTagForElement(MMElement *anElement)
 #pragma mark Public Methods
 //==================================================================================================
 
+- (NSString *) css {
+    return  @"<html>"
+            "<head>"
+            "  <meta charset='UTF-8'/>"
+             " <link rel='stylesheet' href='github.css' type='text/css'/>"
+             "</head>";
+}
+
 - (NSString *) generateHTML:(MMDocument *)aDocument
 {
     NSString   *markdown = aDocument.markdown;
@@ -187,6 +195,7 @@ static NSString * __HTMLEndTagForElement(MMElement *anElement)
     NSUInteger  length   = markdown.length;
     
     NSMutableString *HTML = [NSMutableString stringWithCapacity:length * kHTMLDocumentLengthMultiplier];
+    [HTML appendString: [self css]];
     
     for (MMElement *element in aDocument.elements)
     {


### PR DESCRIPTION
The pull request links directly to a gist for CSS. You can see how that gist visually improves the rendering of the Markdown. 

I think you might consider:
- (NSString *) css {
  return  @"<html>"
          "<head>"
          "  <meta charset='UTF-8'/>"
           " <link rel='stylesheet' href='MMMarkdown.css' type='text/css'/>"
           "</head>";
  }

This would allow people the option of customizing their CSS by providing a CSS file in their resource bundle.  If the resource file is missing your library simply performs like it does today so the change to use a resource based CSS would be backward compatible in all projects.
