### PR TITLE
Turn on SKIP_INSTALL to avoid building generic archives

### DIFF
--- a/MMMarkdown.xcodeproj/project.pbxproj
+++ b/MMMarkdown.xcodeproj/project.pbxproj
@@ -926,6 +926,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "MMMarkdown-iOS";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -938,6 +939,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = "MMMarkdown-iOS";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Turn on SKIP_INSTALL to avoid building generic archives when using Xcode's Archive command.
