### PR TITLE
HTMLStringWithMarkdown:error: throws if string is nil.

### DIFF
--- a/Source/MMMarkdown.m
+++ b/Source/MMMarkdown.m
@@ -39,7 +39,7 @@
 + (NSString *)HTMLStringWithMarkdown:(NSString *)string error:(__autoreleasing NSError **)error
 {
     if (string == nil)
-        return nil;
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"[%@ %@]: nil argument for markdown", NSStringFromClass([self class]), NSStringFromSelector(_cmd)] userInfo:nil];
     if ([string length] == 0)
         return @"";
     

--- a/Tests/MMErrorTests.m
+++ b/Tests/MMErrorTests.m
@@ -44,7 +44,7 @@
 
 - (void)testNilInput
 {
-    STAssertNil([MMMarkdown HTMLStringWithMarkdown:nil error:nil], @"nil input should give nil output");
+    STAssertThrows([MMMarkdown HTMLStringWithMarkdown:nil error:nil], @"nil input should assert");
 }
 
 @end


### PR DESCRIPTION
HTMLStringWithMarkdown now throws if string is nil.

Updated test for new behaviour.

I used @throw instead of NSParameterAssert so the throw occurs even if assertions are off.

Replaces #8.
