### PR TITLE
Added Cocoapods podspec 

### DIFF
--- a/MMMarkdown.podspec.json
+++ b/MMMarkdown.podspec.json
@@ -1,0 +1,23 @@
+{
+  "name": "MMMarkdown",
+  "version": "0.3",
+  "summary": "An Objective-C static library for converting Markdown to HTML.",
+  "homepage": "https://github.com/mdiep/MMMarkdown",
+  "license": {
+    "type": "MIT",
+    "text": "  \t        Copyright (C) 2012-2013 Matt Diephouse.\n\n\t\tPermission is hereby granted, free of charge, to any person obtaining a copy\n\t\tof this software and associated documentation files (the \"Software\"), to deal\n\t\tin the Software without restriction, including without limitation the rights\n\t\tto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n\t\tcopies of the Software, and to permit persons to whom the Software is\n\t\tfurnished to do so, subject to the following conditions:\n\n\t\tThe above copyright notice and this permission notice shall be included in\n\t\tall copies or substantial portions of the Software.\n \n\t\tTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n\t\tIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n\t\tFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n\t\tAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n\t\tLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n\t\tOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n\t\tTHE SOFTWARE.\n"
+  },
+  "authors": {
+    "Matt Diephouse": "matt@diephouse.com"
+  },
+  "source": {
+    "git": "https://github.com/mdiep/MMMarkdown.git",
+    "tag": "0.3"
+  },
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.6"
+  },
+  "source_files": "Source/**/*.{h,m}",
+  "requires_arc": true
+}


### PR DESCRIPTION
Added from Specs-master/Specs/MMMarkdown/0.3/MMMarkdown.podspec.json.

This allows those of us using cocoapods to manage dependencies to pull in the latest master commit of MMMarkdown.  In order to to do that, the pod spec needs to be in the root of the repo as per http://guides.cocoapods.org/using/the-podfile.html#from-a-podspec-in-the-root-of-a-library-repo

All I did was copy the existing pod spec from the Cocoapods master spec repo and put it in the root of the MMMarkdown repo.  This allows me to use MMMarkdown in my project in one of two ways:

```
# Use the latest GM release from cocoapods (currently version 0.3)
pod 'MMMarkdown'

# or use the latest commit to master
pod 'MMMarkdown', :git => 'https://github.com/mdiep/MMMarkdown.git'
```

I have tested both after the change and they both work so this is a low-risk merge.

Thanks for MMMarkdown - I'm really enjoying using it!  :-)
