### PR TITLE
Fix language name edge cases in fenced code blocks

### DIFF
--- a/Source/MMParser.m
+++ b/Source/MMParser.m
@@ -600,13 +600,17 @@ static NSString * __HTMLEntityForCharacter(unichar character)
         return nil;
     
     // skip additional backticks and language
+    [scanner skipWhitespace];
     NSString *language = [scanner nextWord];
-    language = [language isEqual:@""] ? nil : language;
+    scanner.location += language.length;
+    [scanner skipWhitespace];
+    if (!scanner.atEndOfLine)
+        return nil;
     [scanner advanceToNextLine];
     
     MMElement *element = [MMElement new];
     element.type  = MMElementTypeCodeBlock;
-    element.language = language;
+    element.language = (language.length == 0 ? nil : language);
 
     // block ends when it hints a line starting with ``` or the end of the string
     while (!scanner.atEndOfString)

--- a/Tests/MMExtensionTests.m
+++ b/Tests/MMExtensionTests.m
@@ -473,6 +473,36 @@
     );
 }
 
+- (void)testFencedCodeBlockWithSpaceBeforeLanguage
+{
+    MMAssertExtendedMarkdownEqualsHTML(
+        MMMarkdownExtensionsFencedCodeBlocks,
+        @"``` objc\nhello\nworld\n```",
+        @"<pre><code class=\"objc\">hello\nworld\n"
+        "</code></pre>\n"
+    );
+}
+
+- (void)testFencedCodeBlockWithSpaceAfterLanguage
+{
+    MMAssertExtendedMarkdownEqualsHTML(
+        MMMarkdownExtensionsFencedCodeBlocks,
+        @"```objc \nhello\nworld\n```",
+        @"<pre><code class=\"objc\">hello\nworld\n"
+        "</code></pre>\n"
+    );
+}
+
+- (void)testFencedCodeBlockWithSpaceInLanguageName
+{
+    MMAssertExtendedMarkdownEqualsHTML(
+        MMMarkdownExtensionsFencedCodeBlocks,
+        @"```a b\nhello\nworld\n```",
+        @"<p>```a b\nhello\nworld</p>\n<pre><code></code></pre>\n"
+    );
+    
+}
+
 - (void)testFencedCodeBlockInsideBlockquote
 {
     MMAssertExtendedMarkdownEqualsHTML(


### PR DESCRIPTION
This fixes 2 issues with the language name specifier in fenced code blocks:

* Whitespace should be allowed before and after the language name
* Language names must be a single word

Fixes #53.