### PR TITLE
Add test for mathjax markup

### DIFF
--- a/Tests/MMHTMLTests.m
+++ b/Tests/MMHTMLTests.m
@@ -231,5 +231,12 @@
     MMAssertMarkdownEqualsHTML(@"<!------> *hello*-->", @"<!------> *hello*-->");
 }
 
+# pragma mark MathJax tests
+
+- (void)testMathJaxBlock
+{
+    // Mathjax uses $$ and $ for math environments. _ and ^ for sub and super scripts. MMMarkdown should not 'eat' these
+    MMAssertMarkdownEqualsHTML(@"When $x = a_{0} \\times b^{a4}$ then: $$b = c$$", @"<p>When $x = a_{0} \\times b^{a4}$ then: $$b = c$$</p>");
+}
 
 @end


### PR DESCRIPTION
Some Markdown parsers I've found incorrectly convert `_` to `<em>` and various other things.
MMMarkdown doesn't (great!) but I thought it would be worth having a test to keep it this way

http://www.mathjax.org/