### PR TITLE
Allow "=" in autolinked urls.

### DIFF
--- a/Source/MMSpanParser.m
+++ b/Source/MMSpanParser.m
@@ -343,7 +343,7 @@ static NSString * const ESCAPABLE_CHARS = @"\\`*_{}[]()#+-.!>";
 {
     NSCharacterSet        *alphanumerics = NSCharacterSet.alphanumericCharacterSet;
     NSMutableCharacterSet *boringChars = [alphanumerics mutableCopy];
-    [boringChars addCharactersInString:@",_-/:?&;%~!#+"];
+    [boringChars addCharactersInString:@",_-/:?&;%~!#+="];
     
     NSUInteger parenLevel = 0;
     while (1)


### PR DESCRIPTION
I think it makes sense to support "=" in urls. 
Without fix it doesn't work e.g. in this url (link stops after "comment_id"):
"https://www.facebook.com/yaroslav/posts/10152268742977405?comment_id=10152269203352405&offset=0&total_comments=38"