### PR TITLE
Add `-` to allowed characters for inline HTML

### DIFF
--- a/Source/MMHTMLParser.m
+++ b/Source/MMHTMLParser.m
@@ -248,6 +248,7 @@
 {
     NSMutableCharacterSet *nameSet = [NSMutableCharacterSet alphanumericCharacterSet];
     [nameSet addCharactersInString:@":"];
+    [nameSet addCharactersInString:@"-"];
     
     NSRange result = NSMakeRange(scanner.location, 0);
     result.length = [scanner skipCharactersFromSet:nameSet];

--- a/Source/MMHTMLParser.m
+++ b/Source/MMHTMLParser.m
@@ -247,8 +247,7 @@
 - (NSRange)_parseNameWithScanner:(MMScanner *)scanner
 {
     NSMutableCharacterSet *nameSet = [NSMutableCharacterSet alphanumericCharacterSet];
-    [nameSet addCharactersInString:@":"];
-    [nameSet addCharactersInString:@"-"];
+    [nameSet addCharactersInString:@":-"];
     
     NSRange result = NSMakeRange(scanner.location, 0);
     result.length = [scanner skipCharactersFromSet:nameSet];

--- a/Tests/MMHTMLTests.m
+++ b/Tests/MMHTMLTests.m
@@ -87,6 +87,13 @@
     MMAssertMarkdownEqualsHTML(@"<1", @"<p>&lt;1</p>");
 }
 
+- (void)testInlineHTMLWithDataAttributes
+{
+    NSString* html = @"<a href=\"https://example.com/foo.js\" data-card-width=\"100%\">foo</a>";
+    NSString* htmlWithParagraph = [NSString stringWithFormat:@"<p>%@</p>", html];
+    MMAssertMarkdownEqualsHTML(html, htmlWithParagraph);
+}
+
 
 #pragma mark - HTML Comment Tests
 


### PR DESCRIPTION
This allows things like data attributes to work properly in inline HTML.