### PR TITLE
Added `@` character to acceptable URL characters

### DIFF
--- a/Source/MMSpanParser.m
+++ b/Source/MMSpanParser.m
@@ -343,7 +343,7 @@ static NSString * const ESCAPABLE_CHARS = @"\\`*_{}[]()#+-.!>";
 {
     NSCharacterSet        *alphanumerics = NSCharacterSet.alphanumericCharacterSet;
     NSMutableCharacterSet *boringChars = [alphanumerics mutableCopy];
-    [boringChars addCharactersInString:@",_-/:?&;%~!#+="];
+    [boringChars addCharactersInString:@",_-/:?&;%~!#+=@"];
     
     NSUInteger parenLevel = 0;
     while (1)

--- a/Tests/MMLinkTests.m
+++ b/Tests/MMLinkTests.m
@@ -324,5 +324,14 @@
     MMAssertMarkdownEqualsHTML(@"[Foo][bar]", @"<p>[Foo][bar]</p>");
 }
 
+- (void)testLinkRecognitionWithAtSymbol
+{
+    // Use a string comparison for this test because the output is not valid XML
+    NSString *markdown  = @"Have you seen this medium link? https://medium.com/@philipla/the-two-types-of-product-virality-8ae744b1c4d7 It's Great";
+    NSString *generated = [MMMarkdown HTMLStringWithMarkdown:markdown extensions:MMMarkdownExtensionsAutolinkedURLs error:nil];
+    NSString *expected  =  @"<p>Have you seen this medium link? <a href=\"https://medium.com/@philipla/the-two-types-of-product-virality-8ae744b1c4d7\">https://medium.com/@philipla/the-two-types-of-product-virality-8ae744b1c4d7</a> It's Great</p>\n";
+    XCTAssertEqualObjects(generated, expected, @"HTML didn't match expected value");
+}
+
 
 @end


### PR DESCRIPTION
This issue fixes #114 where `@` was not being recognized as a valid URL character in the automatic link detection parser.