### PR TITLE
fixed parsing failure for alternate list and quote.  #116

### DIFF
--- a/Source/MMParser.m
+++ b/Source/MMParser.m
@@ -462,6 +462,20 @@ static NSString * __HTMLEntityForCharacter(unichar character)
             [scanner advance];
             [scanner skipCharactersFromSet:whitespaceSet max:1];
         }
+        else
+        {
+            //
+            // If the following line is a list item
+            // then break the blockquote parsering.
+            //
+            [scanner beginTransaction];
+            [scanner skipIndentationUpTo:2];
+            BOOL hasListMarker = [self _parseListMarkerWithScanner:scanner listType:MMListTypeBulleted]
+            || [self _parseListMarkerWithScanner:scanner listType:MMListTypeNumbered];
+            [scanner commitTransaction:NO];
+            if (hasListMarker)
+                break;
+        }
         
         [element addInnerRange:scanner.currentRange];
         
@@ -851,6 +865,32 @@ static NSString * __HTMLEntityForCharacter(unichar character)
         {
             [self _addTextLineToElement:element withScanner:scanner];
         }
+        
+        [scanner beginTransaction];
+        [scanner skipIndentationUpTo:4];
+        if (scanner.nextCharacter == '>')
+        {
+            //
+            // If next line is start with blockquote mark
+            // then break current list parsering.
+            //
+            // for example:
+            //
+            // > 123
+            // + abc
+            //
+            // "+ abs" should not consider as part of blockquote
+            //
+            // > 234
+            // 567
+            //
+            // "567" is part of the blockquote
+            //
+            [scanner commitTransaction:NO];
+            break;
+        }
+        [scanner commitTransaction:NO];
+        
     }
     
     element.range = NSMakeRange(scanner.startLocation, scanner.location-scanner.startLocation);

--- a/Tests/MMListTests.m
+++ b/Tests/MMListTests.m
@@ -379,6 +379,16 @@
     MMAssertMarkdownEqualsHTML(@" - One\n - Two", @"<ul><li>One</li><li>Two</li></ul>");
 }
 
+- (void)testList_withBold
+{
+    MMAssertMarkdownEqualsHTML(@" - One **Bold**\n - Two", @"<ul><li>One <strong>Bold</strong></li><li>Two</li></ul>");
+}
+
+- (void)testList_withCode
+{
+    MMAssertMarkdownEqualsHTML(@" - One `Code`\n - Two", @"<ul><li>One <code>Code</code></li><li>Two</li></ul>");
+}
+
 - (void)testListFollowingAnotherList
 {
     NSString *markdown =
@@ -416,6 +426,159 @@
          "</ul>\n";
     MMAssertMarkdownEqualsHTML(markdown, HTML);
 }
+
+- (void)testAlternateListAndQuoteWithDoubleNewlines
+{
+    NSString *markdown =
+    @"+ abc\n\n"
+    @"> 123\n\n"
+    @"+ def\n\n"
+    @"> 456\n\n";
+ 
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>123</p>\n"
+    @"</blockquote>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+    
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
+- (void)testAlternateListAndQuote
+{
+    NSString *markdown =
+    @"+ abc\n"
+    @"> 123\n"
+    @"+ def\n"
+    @"> 456\n";
+    
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>123</p>\n"
+    @"</blockquote>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+    
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
+
+- (void)testAlternateListAndQuoteWith3SpaceBeforeQuote
+{
+    NSString *markdown =
+    @"+ abc\n"
+    @"   > 123\n"
+    @"+ def\n"
+    @"> 456\n";
+    
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>123</p>\n"
+    @"</blockquote>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+    
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
+
+- (void)testAlternateListAndQuoteWith4SpaceBeforeQuote
+{
+    NSString *markdown =
+    @"+ abc\n"
+    @"    > 123\n"
+    @"+ def\n"
+    @"> 456\n";
+    
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<pre><code>&gt; 123\n</code></pre>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+    
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
+
+- (void)testAlternateListAndQuoteWith3SpaceBeforeListItem
+{
+    NSString *markdown =
+    @"+ abc\n"
+    @"> 123\n"
+    @"   + def\n"
+    @"> 456\n";
+    
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>123</p>\n"
+    @"</blockquote>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
+
+- (void)testAlternateListAndQuoteWith4SpaceBeforeListItem
+{
+    NSString *markdown =
+    @"+ abc\n"
+    @"> 123\n"
+    @"    + def\n"
+    @"> 456\n";
+    
+    NSString *HTML =
+    @"<ul>\n"
+    @"<li>abc</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>123</p>\n"
+    @"</blockquote>\n"
+    @"<ul>\n"
+    @"<li>def</li>\n"
+    @"</ul>\n"
+    @"<blockquote>\n"
+    @"<p>456</p>\n"
+    @"</blockquote>\n";
+    
+    MMAssertMarkdownEqualsHTML(markdown, HTML);
+}
+
 
 
 @end


### PR DESCRIPTION
fixed parsing failure for alternate list and quote. #116 
added unit test cases.

Alternate list and blockquote will cause parsing failure. 

e.g:

```
+ abc
> 123
+ abc
> 123
```

This pr fix the issue and add unit tests.

The output will be:

```
<ul>
<li>abc</li>
</ul>
<blockquote>
<p>123</p>
</blockquote>
<ul>
<li>abc</li>
</ul>
<blockquote>
<p>123</p>
</blockquote>
```

